### PR TITLE
Remove type provider

### DIFF
--- a/Droid/Elmish.Calculator.Droid.fsproj
+++ b/Droid/Elmish.Calculator.Droid.fsproj
@@ -106,9 +106,6 @@
     <Reference Include="Xamarin.Android.Support.v7.MediaRouter">
       <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Android.FSharp.ResourceProvider.Runtime">
-      <HintPath>..\packages\Xamarin.Android.FSharp.ResourceProvider.1.0.0.22\lib\Xamarin.Android.FSharp.ResourceProvider.Runtime.dll</HintPath>
-    </Reference>
     <Reference Include="Elmish.XamarinForms">
       <HintPath>..\packages\Elmish.XamarinForms.0.4.3\lib\netstandard2.0\Elmish.XamarinForms.dll</HintPath>
     </Reference>

--- a/Droid/MainActivity.fs
+++ b/Droid/MainActivity.fs
@@ -10,16 +10,11 @@ open Android.Widget
 open Android.OS
 open Xamarin.Forms.Platform.Android
 
-type Resources = Elmish.Calculator.Droid.Resource
-
 [<Activity (Label = "Elmish.Calculator.Droid", Icon = "@drawable/icon", Theme = "@style/MyTheme", MainLauncher = true, ConfigurationChanges = (ConfigChanges.ScreenSize ||| ConfigChanges.Orientation))>]
 type MainActivity() =
     inherit FormsAppCompatActivity()
 
     override this.OnCreate (bundle: Bundle) =
-        FormsAppCompatActivity.TabLayoutResource <- Resources.Layout.Tabbar
-        FormsAppCompatActivity.ToolbarResource <- Resources.Layout.Toolbar
-
         base.OnCreate (bundle)
 
         Xamarin.Forms.Forms.Init (this, bundle)

--- a/Droid/packages.config
+++ b/Droid/packages.config
@@ -5,7 +5,6 @@
   <package id="Xamarin.Android.Arch.Core.Common" version="1.0.0" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Arch.Lifecycle.Common" version="1.0.3" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Arch.Lifecycle.Runtime" version="1.0.3" targetFramework="monoandroid81" />
-  <package id="Xamarin.Android.FSharp.ResourceProvider" version="1.0.0.22" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="27.0.2" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Support.Annotations" version="27.0.2" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Support.Compat" version="27.0.2" targetFramework="monoandroid81" />


### PR DESCRIPTION
This is needed to workaround a temporary glitch in the F# compiler on Windows.